### PR TITLE
Add support for Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,13 @@
 
 An icon in the browser shows the number of pull requests currently assigned to you or which require a code review from you.
 
-Just click on the icon to see the pull requests! 
+Just click on the icon to see the pull requests!
 
 ## Install
 
-* Proceed to https://goo.gl/IoKg5m and install the extension
+* Proceed to the following URL and install the extension
+  * Chrome: https://goo.gl/IoKg5m
+  * Firefox: https://mzl.la/2EVTE0o
 * Create a new token for your GitHub account here (https://github.com/settings/tokens/new?description=pull-requests-counter&scopes=repo)
 * Save it and copy it in the options.
 * Save.
@@ -32,4 +34,4 @@ Get your hands on the code :-)
 
 ## Copyright
 
-Coypright 2017 [Renuo AG](https://www.renuo.ch/).
+Coypright 2019 [Renuo AG](https://www.renuo.ch/).

--- a/manifest.json
+++ b/manifest.json
@@ -1,10 +1,13 @@
 {
   "manifest_version": 2,
-  "author": "Renuo GmbH",
+  "author": "Renuo AG",
   "name": "Pull Requests Counter",
   "description": "This extension shows the number of Pull Requests assigned to you.",
   "version": "1.3.1",
-  "options_page": "options.html",
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  },
   "browser_action": {
     "default_icon": "icon.png"
   },
@@ -24,5 +27,11 @@
     "alarms",
     "storage",
     "tabs"
-  ]
+  ],
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "pull-request-counter@renuo.ch",
+      "strict_min_version": "57.0"
+    }
+  }
 }


### PR DESCRIPTION
The add-on has been approved and is available under https://addons.mozilla.org/en-GB/firefox/addon/github-pull-requests-counter/

Closes #6 